### PR TITLE
Multiasset

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Mainnet
 NETWORK=mainnet
-ASSETS="SOL"
+ASSETS=["SOL"]
 PROGRAM_ID=ZETAxsqBRek56DhiGXrn75yj2NHU3aYUnxvHXpkf3aD
 SERVER_BASE_URL=https://mainnet-server.herokuapp.com/
 RPC_URL=https://zeta.rpcpool.com/<RPC-SECRET-KEY>
@@ -13,7 +13,7 @@ SECRET_ACCESS_KEY=<SECRET>
 
 # Devnet
 NETWORK=devnet
-ASSETS="SOL","BTC"
+ASSETS=["SOL","BTC"]
 PROGRAM_ID=BG3oRikW8d16YjUEmX3ZxHm9SiJzrGtMhsSR8aCw1Cd7
 SERVER_BASE_URL=https://server.zeta.markets
 RPC_URL=https://zeta2.devnet.rpcpool.com

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Mainnet
 NETWORK=mainnet
-ASSETS=SOL
+ASSETS="SOL"
 PROGRAM_ID=ZETAxsqBRek56DhiGXrn75yj2NHU3aYUnxvHXpkf3aD
 SERVER_BASE_URL=https://mainnet-server.herokuapp.com/
 RPC_URL=https://zeta.rpcpool.com/<RPC-SECRET-KEY>
@@ -13,7 +13,7 @@ SECRET_ACCESS_KEY=<SECRET>
 
 # Devnet
 NETWORK=devnet
-ASSETS=SOL,BTC
+ASSETS="SOL","BTC"
 PROGRAM_ID=BG3oRikW8d16YjUEmX3ZxHm9SiJzrGtMhsSR8aCw1Cd7
 SERVER_BASE_URL=https://server.zeta.markets
 RPC_URL=https://zeta2.devnet.rpcpool.com

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Mainnet
 NETWORK=mainnet
+ASSETS=SOL
 PROGRAM_ID=ZETAxsqBRek56DhiGXrn75yj2NHU3aYUnxvHXpkf3aD
 SERVER_BASE_URL=https://mainnet-server.herokuapp.com/
 RPC_URL=https://zeta.rpcpool.com/<RPC-SECRET-KEY>
@@ -12,6 +13,7 @@ SECRET_ACCESS_KEY=<SECRET>
 
 # Devnet
 NETWORK=devnet
+ASSETS=SOL,BTC
 PROGRAM_ID=BG3oRikW8d16YjUEmX3ZxHm9SiJzrGtMhsSR8aCw1Cd7
 SERVER_BASE_URL=https://server.zeta.markets
 RPC_URL=https://zeta2.devnet.rpcpool.com

--- a/event-queue-processing.ts
+++ b/event-queue-processing.ts
@@ -4,6 +4,7 @@ import {
   Market,
   programTypes,
   utils,
+  assets,
 } from "@zetamarkets/sdk";
 import { Network, utils as FlexUtils } from "@zetamarkets/flex-sdk";
 import { SYSVAR_CLOCK_PUBKEY } from "@solana/web3.js";
@@ -25,7 +26,10 @@ const network =
     ? Network.DEVNET
     : Network.LOCALNET;
 
-export async function collectMarketData(lastSeqNum?: Record<number, number>) {
+export async function collectMarketData(
+  asset: assets.Asset,
+  lastSeqNum?: Record<number, Record<number, number>>
+) {
   let accountInfo;
   try {
     accountInfo = await Exchange.connection.getAccountInfo(SYSVAR_CLOCK_PUBKEY);
@@ -37,7 +41,7 @@ export async function collectMarketData(lastSeqNum?: Record<number, number>) {
   let timestamp = clockData.timestamp;
 
   await Promise.all(
-    Exchange.markets.markets.map(async (market) => {
+    Exchange.getMarkets(asset).map(async (market) => {
       let expirySeries = market.expirySeries;
 
       // Fetch trades if the market is active or
@@ -52,7 +56,7 @@ export async function collectMarketData(lastSeqNum?: Record<number, number>) {
       let marketIndex = market.marketIndex;
       if (!fetchingMarkets[marketIndex]) {
         fetchingMarkets[marketIndex] = true;
-        await collectEventQueue(market, lastSeqNum);
+        await collectEventQueue(asset, market, lastSeqNum);
         fetchingMarkets[marketIndex] = false;
       }
     })
@@ -60,6 +64,7 @@ export async function collectMarketData(lastSeqNum?: Record<number, number>) {
 }
 
 async function fetchTrades(
+  asset: assets.Asset,
   market: Market,
   lastSeqNum?: number
 ): Promise<[Trade[], number]> {
@@ -140,10 +145,7 @@ async function fetchTrades(
 
     let expirySeries = market.expirySeries;
 
-    let underlying = FlexUtils.getUnderlyingMapping(
-      network,
-      Exchange.zetaGroup.underlyingMint
-    );
+    let underlying = assets.assetToName(asset);
 
     let newTradeObject: Trade = {
       seq_num: newLastSeqNum - events.length + i + 1,
@@ -170,14 +172,16 @@ async function fetchTrades(
 }
 
 async function collectEventQueue(
+  asset: assets.Asset,
   market: Market,
-  lastSeqNum?: Record<number, number>
+  lastSeqNum?: Record<number, Record<number, number>>
 ) {
   const [trades, currentSeqNum] = await fetchTrades(
+    asset,
     market,
-    lastSeqNum[market.marketIndex]
+    lastSeqNum[asset][market.marketIndex]
   );
-  lastSeqNum[market.marketIndex] = currentSeqNum;
+  lastSeqNum[asset][market.marketIndex] = currentSeqNum;
   if (trades.length > 0) {
     putDynamo(trades, process.env.DYNAMO_TABLE_NAME);
     putFirehoseBatch(trades, process.env.FIREHOSE_DS_NAME);

--- a/event-queue-processing.ts
+++ b/event-queue-processing.ts
@@ -6,7 +6,6 @@ import {
   utils,
   assets,
 } from "@zetamarkets/sdk";
-import { Network, utils as FlexUtils } from "@zetamarkets/flex-sdk";
 import { SYSVAR_CLOCK_PUBKEY } from "@solana/web3.js";
 import { Trade } from "./utils/types";
 import { decodeRecentEvents } from "./utils";
@@ -18,13 +17,6 @@ import { alert } from "./utils/telegram";
 
 let fetchingMarkets: boolean[];
 fetchingMarkets = new Array(constants.ACTIVE_MARKETS).fill(false);
-
-const network =
-  process.env.NETWORK === "mainnet"
-    ? Network.MAINNET
-    : process.env.NETWORK === "devnet"
-    ? Network.DEVNET
-    : Network.LOCALNET;
 
 export async function collectMarketData(
   asset: assets.Asset,

--- a/index.ts
+++ b/index.ts
@@ -42,7 +42,7 @@ export const loadExchange = async (
 const main = async () => {
   let allAssetsStr: string[] = process.env.ASSETS!.split(",");
   let allAssets = allAssetsStr.map((assetStr) => {
-    return assets.nameToAsset(assetStr);
+    return assets.nameToAsset(assetStr.trim());
   });
   await loadExchange(allAssets);
 

--- a/index.ts
+++ b/index.ts
@@ -40,9 +40,13 @@ export const loadExchange = async (
 };
 
 const main = async () => {
-  let allAssetsStr: string[] = process.env.ASSETS!.split(",");
-  let allAssets = allAssetsStr.map((assetStr) => {
-    return assets.nameToAsset(assetStr.trim());
+  let assetsJson = process.env.ASSETS!;
+  if (assetsJson[0] != "[" && assetsJson[-1] != "]") {
+    assetsJson = "[" + assetsJson + "]";
+  }
+  let assetsStrings: string[] = JSON.parse(assetsJson);
+  let allAssets = assetsStrings.map((assetStr) => {
+    return assets.nameToAsset(assetStr);
   });
   await loadExchange(allAssets);
 

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import { Exchange, Network, utils } from "@zetamarkets/sdk";
+import { Exchange, Network, utils, assets } from "@zetamarkets/sdk";
 import { PublicKey, Connection } from "@solana/web3.js";
 import { collectMarketData } from "./event-queue-processing";
 import { FETCH_INTERVAL } from "./utils/constants";
@@ -12,11 +12,16 @@ const network =
     ? Network.DEVNET
     : Network.LOCALNET;
 
-export const loadExchange = async (reload?: boolean) => {
+export const loadExchange = async (
+  allAssets: assets.Asset[],
+  reload?: boolean
+) => {
   try {
     alert(`${reload ? "Reloading" : "Loading"} exchange...`, false);
     const connection = new Connection(process.env.RPC_URL, "finalized");
+
     await Exchange.load(
+      allAssets,
       new PublicKey(process.env.PROGRAM_ID),
       network,
       connection,
@@ -30,25 +35,37 @@ export const loadExchange = async (reload?: boolean) => {
     await Exchange.close();
   } catch (e) {
     alert(`Failed to ${reload ? "reload" : "load"} exchange: ${e}`, true);
-    loadExchange(true);
+    loadExchange(allAssets, true);
   }
 };
 
 const main = async () => {
-  await loadExchange();
+  let allAssetsStr: string[] = process.env.ASSETS!.split(",");
+  let allAssets = allAssetsStr.map((assetStr) => {
+    return assets.nameToAsset(assetStr);
+  });
+  await loadExchange(allAssets);
 
-  // Each market has it own sequence number
+  // Each asset/market has it own sequence number
   let { lastSeqNum } = await getLastSeqNumMetadata(process.env.BUCKET_NAME);
   if (!lastSeqNum) {
     lastSeqNum = {};
   }
 
+  for (const asset of allAssets) {
+    if (!(asset in lastSeqNum)) {
+      lastSeqNum[asset] = {};
+    }
+  }
+
   setInterval(async () => {
-    loadExchange(true);
+    loadExchange(allAssets, true);
   }, 10_800_000); // Refresh every 3 hours
 
   setInterval(async () => {
-    collectMarketData(lastSeqNum);
+    allAssets.map((asset) => {
+      collectMarketData(asset, lastSeqNum);
+    });
   }, FETCH_INTERVAL);
 
   setInterval(async () => {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
     "@project-serum/serum": "0.13.55",
     "@solana/buffer-layout": "^4.0.0",
     "@solana/web3.js": "^1.36.0",
-    "@zetamarkets/flex-sdk": "^0.5.1",
     "@zetamarkets/sdk": "0.15.0-beta.13",
     "aws-sdk": "^2.1047.0",
     "dotenv": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "@solana/buffer-layout": "^4.0.0",
     "@solana/web3.js": "^1.36.0",
     "@zetamarkets/flex-sdk": "^0.5.1",
-    "@zetamarkets/sdk": "^0.13.1",
+    "@zetamarkets/sdk": "0.15.0-beta.13",
     "aws-sdk": "^2.1047.0",
     "dotenv": "^10.0.0",
     "ts-node": "^7.0.1",

--- a/utils/s3.ts
+++ b/utils/s3.ts
@@ -6,7 +6,7 @@ let s3 = new AWS.S3(AWSOptions);
 
 export const putLastSeqNumMetadata = async (
   bucketName: string,
-  lastSeqNum: Record<number, number> | undefined
+  lastSeqNum: Record<number, Record<number, number>> | undefined
 ) => {
   let data = JSON.stringify({ lastSeqNum });
   await s3
@@ -30,7 +30,7 @@ export const getLastSeqNumMetadata = async (bucketName: string) => {
       .promise();
     return JSON.parse(data.Body.toString("utf-8"));
   } catch (error) {
-    alert(`Failed to fetch last seqnum: ${error}`, true)
+    alert(`Failed to fetch last seqnum: ${error}`, true);
     return { lastSeqNum: undefined };
   }
 };


### PR DESCRIPTION
Index trades from all assets at the same time. We change the format of `lastSeqNum` to hold `asset` in the first layer, and then call `collectMarketData()` for each asset in the same timer.

Example data of me manually trading in BTC: https://s3.console.aws.amazon.com/s3/object/zetadex-devnet?region=ap-southeast-1&prefix=trades/raw/data/year%3D2022/month%3D06/day%3D24/hour%3D04/PUT-S3-zetadex-devnet-trades-5-2022-06-24-04-55-45-36d96971-6376-4184-95da-ef1baf62f8ff

Running it locally clashes a little bit with the actual devnet indexer so I'm happy to push it to devnet quickly if everyone's happy with it so we can check the data :) 