### PR TITLE
Bump SDK to 0.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@project-serum/serum": "0.13.55",
     "@solana/buffer-layout": "^4.0.0",
     "@solana/web3.js": "^1.36.0",
-    "@zetamarkets/sdk": "0.16.0",
+    "@zetamarkets/sdk": "0.17.0",
     "aws-sdk": "^2.1047.0",
     "dotenv": "^10.0.0",
     "ts-node": "^7.0.1",


### PR DESCRIPTION
Fixes exchange loading issues that are spamming the Zeta Indexer Alerting chat. Shouldn't be any breaking changes, and I ran it fine locally