### PR TITLE
Patch trade indexer for multiasset

### DIFF
--- a/utils/s3.ts
+++ b/utils/s3.ts
@@ -29,8 +29,10 @@ export const getLastSeqNumMetadata = async (bucketName: string) => {
       })
       .promise();
     return JSON.parse(data.Body.toString("utf-8"));
-  } catch (error) {
-    logger.error("Failed to fetch last seqnum", { error });
+  } catch (e) {
+    logger.error("Failed to fetch last seqnum", {
+      error: (e as Error).message,
+    });
     return { lastSeqNum: undefined };
   }
 };


### PR DESCRIPTION
Issue: we were experiencing no BTC/ETH trades being indexed. This was because the data structure for blocking fetch calls was not adapted for multiasset and hence SOL market fetches would block say BTC ones. 

1. Fixed indexing bugs for BTC/ETH due to fetch blocking not being adapted to multiasset. 
2. Cleaned up asset indices now string from integer (we lost a bunch of trades here). 
3. Added more logging.

Tested locally and seems to be working. Unfortunately means we lost a few days of BTC and ETH trade data. I reset the checkpoint indices but seemingly the cranking volume of events must have pushed them off the event queue so they're no longer recoverable...